### PR TITLE
Remove incorrect PHPDoc @return tags, so IDEs can provide autocompletion

### DIFF
--- a/src/Endpoints/Collections.php
+++ b/src/Endpoints/Collections.php
@@ -8,8 +8,6 @@ trait Collections
      * List collections
      * Get a single page from the list of all collections.
      * @link https://unsplash.com/documentation#list-collections
-     *
-     * @return MarkSitko\LaravelUnsplash\Endpoints\Collections
      */
     public function collectionsList()
     {
@@ -23,8 +21,6 @@ trait Collections
      * List featured collections
      * Get a single page from the list of featured collections.
      * @link https://unsplash.com/documentation#list-featured-collections
-     *
-     * @return MarkSitko\LaravelUnsplash\Endpoints\Collections
      */
     public function featuredCollection()
     {
@@ -40,7 +36,6 @@ trait Collections
      * @link https://unsplash.com/documentation#get-a-collection
      *
      * @param int|string $id The collections’s ID. Required.
-     * @return MarkSitko\LaravelUnsplash\Endpoints\Collections
      */
     public function showCollection( $id )
     {
@@ -56,7 +51,6 @@ trait Collections
      * @link https://unsplash.com/documentation#get-a-collections-photos
      *
      * @param int|string $id The collections’s ID. Required.
-     * @return MarkSitko\LaravelUnsplash\Endpoints\Collections
      */
     public function showCollectionPhotos( $id )
     {
@@ -72,7 +66,6 @@ trait Collections
      * @link https://unsplash.com/documentation#list-a-collections-related-collections
      *
      * @param int|string $id The collections’s ID. Required.
-     * @return MarkSitko\LaravelUnsplash\Endpoints\Collections
      */
     public function showCollectionRelatedCollections( $id )
     {

--- a/src/Endpoints/Photos.php
+++ b/src/Endpoints/Photos.php
@@ -8,8 +8,6 @@ trait Photos
      * List photos
      * Get a single page from the list of all photos.
      * @link https://unsplash.com/documentation#list-photos
-     *
-     * @return MarkSitko\LaravelUnsplash\Endpoints\Photos
      */
     public function photos()
     {
@@ -25,7 +23,6 @@ trait Photos
      * @link https://unsplash.com/documentation#get-a-photo
      *
      * @param string $id
-     * @return MarkSitko\LaravelUnsplash\Endpoints\Photos
      */
     public function photo( $id )
     {
@@ -38,8 +35,6 @@ trait Photos
     /**
      * Get a random photo
      * @link https://unsplash.com/documentation#get-a-random-photo
-     *
-     * @return MarkSitko\LaravelUnsplash\Endpoints\Photos
      */
     public function randomPhoto()
     {
@@ -54,7 +49,6 @@ trait Photos
      * @link https://unsplash.com/documentation#get-a-photos-statistics
      *
      * @param string $id
-     * @return MarkSitko\LaravelUnsplash\Endpoints\Photos
      */
     public function photosStatistics($id)
     {
@@ -69,7 +63,6 @@ trait Photos
      * @link https://unsplash.com/documentation#track-a-photo-download
      *
      * @param string $id
-     * @return MarkSitko\LaravelUnsplash\Endpoints\Photos
      */
     public function trackPhotoDownload($id)
     {

--- a/src/Endpoints/Search.php
+++ b/src/Endpoints/Search.php
@@ -8,8 +8,6 @@ trait Search
      * Search photos
      * Get a single page of photo results for a query.
      * @link https://unsplash.com/documentation#search-photos
-     *
-     * @return MarkSitko\LaravelUnsplash\Endpoints\Search
      */
     public function search()
     {
@@ -23,8 +21,6 @@ trait Search
      * Search collections
      * Get a single page of collection results for a query.
      * @link https://unsplash.com/documentation#search-collections
-     *
-     * @return MarkSitko\LaravelUnsplash\Endpoints\Search
      */
     public function searchCollections()
     {
@@ -38,8 +34,6 @@ trait Search
      * Search users
      * Get a single page of user results for a query.
      * @link https://unsplash.com/documentation#search-users
-     *
-     * @return MarkSitko\LaravelUnsplash\Endpoints\Search
      */
     public function searchUsers()
     {

--- a/src/Endpoints/Stats.php
+++ b/src/Endpoints/Stats.php
@@ -8,8 +8,6 @@ trait Stats
      * Totals
      * Get a list of counts for all of Unsplash.
      * @link https://unsplash.com/documentation#totals
-     *
-     * @return MarkSitko\LaravelUnsplash\Endpoints\Stats
      */
     public function totalStats()
     {
@@ -23,8 +21,6 @@ trait Stats
      * Month
      * Get the overall Unsplash stats for the past 30 days.
      * @link https://unsplash.com/documentation#month
-     *
-     * @return MarkSitko\LaravelUnsplash\Endpoints\Stats
      */
     public function monthlyStats()
     {

--- a/src/Endpoints/Users.php
+++ b/src/Endpoints/Users.php
@@ -10,7 +10,6 @@ trait Users
      * @link https://unsplash.com/documentation#get-a-users-public-profile
      *
      * @param string $username The user’s username. Required.
-     * @return MarkSitko\LaravelUnsplash\Endpoints\Users
      */
     public function user( $username )
     {
@@ -26,7 +25,6 @@ trait Users
      * @link https://unsplash.com/documentation#get-a-users-portfolio-link
      *
      * @param string $username The user’s username. Required.
-     * @return MarkSitko\LaravelUnsplash\Endpoints\Users
      */
     public function userPortfolio( $username )
     {
@@ -42,7 +40,6 @@ trait Users
      * @link https://unsplash.com/documentation#list-a-users-photos
      *
      * @param string $username The user’s username. Required.
-     * @return MarkSitko\LaravelUnsplash\Endpoints\Users
      */
     public function userPhotos( $username )
     {
@@ -58,7 +55,6 @@ trait Users
      * @link https://unsplash.com/documentation#list-a-users-liked-photos
      *
      * @param string $username The user’s username. Required.
-     * @return MarkSitko\LaravelUnsplash\Endpoints\Users
      */
     public function userLikes( $username )
     {
@@ -74,7 +70,6 @@ trait Users
      * @link https://unsplash.com/documentation#list-a-users-collections
      *
      * @param string $username The user’s username. Required.
-     * @return MarkSitko\LaravelUnsplash\Endpoints\Users
      */
     public function userCollections( $username )
     {
@@ -91,7 +86,6 @@ trait Users
      * @link https://unsplash.com/documentation#get-a-users-statistics
      *
      * @param string $username The user’s username. Required.
-     * @return MarkSitko\LaravelUnsplash\Endpoints\Users
      */
     public function userStatistics( $username )
     {

--- a/src/Queries/QueryBuilder.php
+++ b/src/Queries/QueryBuilder.php
@@ -11,7 +11,6 @@ trait QueryBuilder
     /**
      * Page number to retrive.
      * @param int|string $param
-     * @return MarkSitko\LaravelUnsplash\Queries\QueryBuilder
      */
     public function page( $param = null )
     {
@@ -22,7 +21,6 @@ trait QueryBuilder
     /**
      * Number of items per page
      * @param int|string $param
-     * @return MarkSitko\LaravelUnsplash\Queries\QueryBuilder
      */
     public function perPage( $param = null )
     {
@@ -33,7 +31,6 @@ trait QueryBuilder
     /**
      * How to sort the photos.
      * @param int|string $param Valid values: latest, oldest, popular
-     * @return MarkSitko\LaravelUnsplash\Queries\QueryBuilder
      */
     public function orderBy( $param = null )
     {
@@ -47,7 +44,6 @@ trait QueryBuilder
     /**
      * Public collection ID(‘s) to filter selection. If multiple, comma-separated.
      * @param string $param
-     * @return MarkSitko\LaravelUnsplash\Queries\QueryBuilder
      */
     public function collections( $param = null )
     {
@@ -58,7 +54,6 @@ trait QueryBuilder
     /**
      * Limit selection to featured photos.
      * @param string $param
-     * @return MarkSitko\LaravelUnsplash\Queries\QueryBuilder
      */
     public function featured( $param = null )
     {
@@ -69,7 +64,6 @@ trait QueryBuilder
     /**
      * Limit selection to a single user.
      * @param string $param
-     * @return MarkSitko\LaravelUnsplash\Queries\QueryBuilder
      */
     public function username( $param = null )
     {
@@ -80,7 +74,6 @@ trait QueryBuilder
     /**
      * Filter search results by photo orientation.
      * @param string $param Valid values: landscape, portrait, and squarish
-     * @return MarkSitko\LaravelUnsplash\Queries\QueryBuilder
      */
     public function orientation( $param = null )
     {
@@ -91,7 +84,6 @@ trait QueryBuilder
     /**
      * Limit selection to photos matching a search term.
      * @param string $param
-     * @return MarkSitko\LaravelUnsplash\Queries\QueryBuilder
      */
     public function term( $param = null )
     {
@@ -102,7 +94,6 @@ trait QueryBuilder
     /**
      * The number of photos to return.
      * @param int|string $param min 1, max 30
-     * @return MarkSitko\LaravelUnsplash\Queries\QueryBuilder
      */
     public function count( $param = null )
     {
@@ -116,7 +107,6 @@ trait QueryBuilder
     /**
      * The public id of the photo.
      * @param int|string $param required
-     * @return MarkSitko\LaravelUnsplash\Queries\QueryBuilder
      */
     public function id( $param = null )
     {
@@ -127,7 +117,6 @@ trait QueryBuilder
     /**
      * The frequency of the stats.
      * @param string $param default days
-     * @return MarkSitko\LaravelUnsplash\Queries\QueryBuilder
      */
     public function resolution( $param = null )
     {
@@ -138,7 +127,6 @@ trait QueryBuilder
     /**
      * The amount of for each stat.
      * @param int|string $param
-     * @return MarkSitko\LaravelUnsplash\Queries\QueryBuilder
      */
     public function quantity( $param = null )
     {
@@ -152,7 +140,6 @@ trait QueryBuilder
     /**
      * Filter results by color.
      * @param string $param Valid values are: black_and_white, black, white, yellow, orange, red, purple, magenta, green, teal, and blue.
-     * @return MarkSitko\LaravelUnsplash\Queries\QueryBuilder
      */
     public function color( $param = null )
     {
@@ -163,7 +150,6 @@ trait QueryBuilder
     /**
      * Query for search terms
      * @param string $param
-     * @return MarkSitko\LaravelUnsplash\Queries\QueryBuilder
      */
     public function query( $param = null )
     {


### PR DESCRIPTION
In PhpStorm, autocompletion of methods is currently broken for this package. For example, `Unsplash::search()->term('test')->toJson()` stops all autocompletion after the `search()` method.

PhpStorm does not recognise the chained `term()` or `toJson()` methods because the traits all set self-referential `@return` docblock tags:

```php
     /**
      * Search photos
      * Get a single page of photo results for a query.
      * @link https://unsplash.com/documentation#search-photos
      *
      * @return MarkSitko\LaravelUnsplash\Endpoints\Search
      */
     public function search()
     {
        $this->apiCall = [
            'endpoint' => 'search/photos',
        ];
        return $this;
    }
```

Because of this `@return` tag, PhpStorm assumes `return $this;` is returning another instance of the `Search` trait — when it's actually returning the original instance of `\MarkSitko\LaravelUnsplash\Unsplash` (via inheritance of the `UnsplashAPI` trait).

Removing these `@return` tags lets PhpStorm parse the class inheritance correctly, and provide full autocompletion.

Thanks for a great package!